### PR TITLE
Roll on each process run

### DIFF
--- a/src/Serilog.Sinks.PersistentFile/FileLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.PersistentFile/FileLoggerConfigurationExtensions.cs
@@ -166,7 +166,7 @@ namespace Serilog
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="formatter">A formatter, such as <see cref="JsonFormatter"/>, to convert the log events into
         /// text for the file. If control of regular text formatting is required, use the other
-        /// overload of <see cref="PersistentFile(Serilog.Configuration.LoggerSinkConfiguration,string,Serilog.Events.LogEventLevel,string,System.IFormatProvider,System.Nullable{long},Serilog.Core.LoggingLevelSwitch,bool,bool,System.Nullable{System.TimeSpan},Serilog.PersistentFileRollingInterval,bool,System.Nullable{int},System.Text.Encoding,Serilog.Sinks.PersistentFile.FileLifecycleHooks,bool)"/>
+        /// overload of <see cref="PersistentFile(Serilog.Configuration.LoggerSinkConfiguration,string,Serilog.Events.LogEventLevel,string,System.IFormatProvider,System.Nullable{long},Serilog.Core.LoggingLevelSwitch,bool,bool,System.Nullable{System.TimeSpan})"/>
         /// and specify the outputTemplate parameter instead.
         /// </param>
         /// <param name="path">Path to the file.</param>
@@ -235,6 +235,7 @@ namespace Serilog
         /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8 without BOM.</param>
         /// <param name="hooks">Optionally enables hooking into log file lifecycle events.</param>
         /// <param name="preserveLogFilename">Avoid the log file name to change after each roll, on roll the log file is copied to a new file and the current file is restarted empty</param>
+        /// <param name="rollOnEachProcessRun">Roll the name of the log file every time the process starts.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration PersistentFile(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -252,7 +253,8 @@ namespace Serilog
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             Encoding encoding = null,
             FileLifecycleHooks hooks = null,
-            bool preserveLogFilename = true)
+            bool preserveLogFilename = true,
+            bool rollOnEachProcessRun = true)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (path == null) throw new ArgumentNullException(nameof(path));
@@ -261,7 +263,8 @@ namespace Serilog
             var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
             return PersistentFile(sinkConfiguration, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes,
                 levelSwitch, buffered, shared, flushToDiskInterval,
-                persistentFileRollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, hooks, preserveLogFilename);
+                persistentFileRollingInterval, rollOnFileSizeLimit, retainedFileCountLimit, encoding, hooks,
+                preserveLogFilename, rollOnEachProcessRun);
         }
 
         /// <summary>
@@ -270,7 +273,7 @@ namespace Serilog
         /// <param name="sinkConfiguration">Logger sink configuration.</param>
         /// <param name="formatter">A formatter, such as <see cref="JsonFormatter"/>, to convert the log events into
         /// text for the file. If control of regular text formatting is required, use the other
-        /// overload of <see cref="PersistentFile(Serilog.Configuration.LoggerSinkConfiguration,string,Serilog.Events.LogEventLevel,string,System.IFormatProvider,System.Nullable{long},Serilog.Core.LoggingLevelSwitch,bool,bool,System.Nullable{System.TimeSpan},Serilog.PersistentFileRollingInterval,bool,System.Nullable{int},System.Text.Encoding,Serilog.Sinks.PersistentFile.FileLifecycleHooks,bool)"/>
+        /// overload of <see cref="PersistentFile(Serilog.Configuration.LoggerSinkConfiguration,string,Serilog.Events.LogEventLevel,string,System.IFormatProvider,System.Nullable{long},Serilog.Core.LoggingLevelSwitch,bool,bool,System.Nullable{System.TimeSpan})"/>
         /// and specify the outputTemplate parameter instead.
         /// </param>
         /// <param name="path">Path to the file.</param>
@@ -292,7 +295,8 @@ namespace Serilog
         /// including the current log file. For unlimited retention, pass null. The default is 31.</param>
         /// <param name="encoding">Character encoding used to write the text file. The default is UTF-8 without BOM.</param>
         /// <param name="hooks">Optionally enables hooking into log file lifecycle events.</param>
-        /// <param name="preserveLogFilename">Preserve the name of the log file, and copy content on roll to a new file</param>
+        /// <param name="preserveLogFilename">Preserve the name of the log file, and copy content on roll to a new file.</param>
+        /// <param name="rollOnEachProcessRun">Roll the name of the log file every time the process starts.</param>
         /// <returns>Configuration object allowing method chaining.</returns>
         public static LoggerConfiguration PersistentFile(
             this LoggerSinkConfiguration sinkConfiguration,
@@ -309,7 +313,8 @@ namespace Serilog
             int? retainedFileCountLimit = DefaultRetainedFileCountLimit,
             Encoding encoding = null,
             FileLifecycleHooks hooks = null,
-            bool preserveLogFilename = true)
+            bool preserveLogFilename = true,
+            bool rollOnEachProcessRun = true)
         {
             if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -317,7 +322,7 @@ namespace Serilog
 
             return ConfigureFile(sinkConfiguration.Sink, formatter, path, restrictedToMinimumLevel, fileSizeLimitBytes, levelSwitch,
                 buffered, false, shared, flushToDiskInterval, encoding, persistentFileRollingInterval, rollOnFileSizeLimit,
-                retainedFileCountLimit, hooks, preserveLogFilename);
+                retainedFileCountLimit, hooks, preserveLogFilename, rollOnEachProcessRun);
         }
 
         /// <summary>
@@ -456,7 +461,8 @@ namespace Serilog
             bool rollOnFileSizeLimit,
             int? retainedFileCountLimit,
             FileLifecycleHooks hooks,
-            bool preserveLogFilename = true)
+            bool preserveLogFilename = true,
+            bool rollOnEachProcessRun = true)
         {
             if (addSink == null) throw new ArgumentNullException(nameof(addSink));
             if (formatter == null) throw new ArgumentNullException(nameof(formatter));
@@ -470,7 +476,7 @@ namespace Serilog
 
             if (rollOnFileSizeLimit || persistentFileRollingInterval != PersistentFileRollingInterval.Infinite)
             {
-                sink = new RollingFileSink(path, formatter, fileSizeLimitBytes, retainedFileCountLimit, encoding, buffered, shared, persistentFileRollingInterval, rollOnFileSizeLimit, hooks, preserveLogFilename);
+                sink = new RollingFileSink(path, formatter, fileSizeLimitBytes, retainedFileCountLimit, encoding, buffered, shared, persistentFileRollingInterval, rollOnFileSizeLimit, hooks, preserveLogFilename, rollOnEachProcessRun);
             }
             else
             {

--- a/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/RollingFileSink.cs
+++ b/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/RollingFileSink.cs
@@ -193,7 +193,7 @@ namespace Serilog.Sinks.PersistentFile
                             }
                             catch (IOException ex)
                             {
-                                if (IOErrors.IsLockedFile(ex))
+                                if (IOErrors.IsLockedFile(ex) || File.Exists(path))
                                 {
                                     SelfLog.WriteLine(
                                         "File target {0} was locked, attempting to open next in sequence (attempt {1})",

--- a/test/Serilog.Sinks.PersistentFile.Tests/RollingFileSinkTests.cs
+++ b/test/Serilog.Sinks.PersistentFile.Tests/RollingFileSinkTests.cs
@@ -4,10 +4,10 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
-using Xunit;
+using Serilog.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.PersistentFile.Tests.Support;
-using Serilog.Configuration;
+using Xunit;
 
 namespace Serilog.Sinks.PersistentFile.Tests
 {
@@ -256,6 +256,75 @@ namespace Serilog.Sinks.PersistentFile.Tests
                 Assert.True(files[0].EndsWith(fileName), files[0]);
                 Assert.True(files[1].EndsWith( e2.Timestamp.ToString("yyyyMMdd")+".txt"), files[1]);
                 Assert.True(files[2].EndsWith(e3.Timestamp.ToString("yyyyMMdd")+".txt"), files[2]);
+            }
+        }
+
+        [Fact]
+        static void LogFilenameShouldNotChangeOnMultipleRunsWhenRollOnEachProcessRunIsFalse()
+        {
+            var fileName = "mylogfile.txt";
+            using (var temp = new TempFolder())
+            {
+                MakeRunAndWriteLog(temp);
+                MakeRunAndWriteLog(temp);
+                MakeRunAndWriteLog(temp);
+
+                var files = Directory.GetFiles(temp.Path)
+                    .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                Assert.Equal(1, files.Length);
+                Assert.True(files[0].EndsWith(fileName), files[0]);
+            }
+
+            void MakeRunAndWriteLog(TempFolder temp)
+            {
+                using (var log = new LoggerConfiguration()
+                    .WriteTo.PersistentFile(Path.Combine(temp.Path, fileName), retainedFileCountLimit: null,
+                        preserveLogFilename: true, persistentFileRollingInterval: PersistentFileRollingInterval.Day,
+                        rollOnEachProcessRun: false)
+                    .CreateLogger())
+                {
+                    var e1 = Some.InformationEvent();
+                    Clock.SetTestDateTimeNow(e1.Timestamp.DateTime);
+                    log.Write(e1);
+                }
+            }
+        }
+
+        [Fact]
+        static void LogFilenameShouldChangeOnMultipleRunsWhenRollOnEachProcessRunIsTrue()
+        {
+            var fileName = "mylogfile.txt";
+            using (var temp = new TempFolder())
+            {
+                MakeRunAndWriteLog(temp, out _);
+                MakeRunAndWriteLog(temp, out var t1);
+                MakeRunAndWriteLog(temp, out _);
+
+                var files = Directory.GetFiles(temp.Path)
+                    .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                Assert.Equal(3, files.Length);
+                Assert.True(files[0].EndsWith(fileName), files[0]);
+                Assert.True(files[1].EndsWith(t1.ToString("yyyyMMdd")+".txt"), files[1]);
+                Assert.True(files[2].EndsWith(t1.ToString("yyyyMMdd")+"_001.txt"), files[1]);
+            }
+
+            void MakeRunAndWriteLog(TempFolder temp, out DateTime timestamp)
+            {
+                using (var log = new LoggerConfiguration()
+                    .WriteTo.PersistentFile(Path.Combine(temp.Path, fileName), retainedFileCountLimit: null,
+                        preserveLogFilename: true, persistentFileRollingInterval: PersistentFileRollingInterval.Day,
+                        rollOnEachProcessRun: true)
+                    .CreateLogger())
+                {
+                    var e1 = Some.InformationEvent();
+                    timestamp = e1.Timestamp.DateTime;
+                    Clock.SetTestDateTimeNow(timestamp);
+                    log.Write(e1);
+                }
             }
         }
 

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net5.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Serilog.Sinks.PersistentFile.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
@@ -9,7 +9,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Serilog.Sinks.PeristentFile.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-     <PackageTargetFallback  Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
     <!-- <PackageTargetFallback >$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback> -->
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>


### PR DESCRIPTION
I added the option `rollOnEachProcessRun` to `LoggerConfiguration` which, if set to `false`, mimics the behaviour of log4net. That is:
- Run 1 on day 1: `logfile.log` is created.
- Run 2 on day 1: logs are appended to `logfile.log`
- Run 1 on day 2: old log file is rolled to `logfile20210521.log` (or `logfile20210521-001.log` etc. if locked or if it already existed) and a new `logfile.log` is created.
- Run 2 on day 2: logs are appended to day 2's `logfile.log`
- ...and so on.

Those changes should not be breaking, because the option `rollOnEachProcessRun` is defaulted to `true` which is the previous behaviour. I also added some unit tests for completeness.