### PR TITLE
Set Access property of FileStreamOptions to FileAccess.Write

### DIFF
--- a/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
@@ -102,7 +102,7 @@ namespace Serilog.Sinks.PersistentFile
                         _fileOutput = new FileStream(
                             _path,
                             new FileStreamOptions{
-                                Access = FileAccess.ReadWrite,
+                                Access = FileAccess.Write,
                                 Mode = FileMode.Append,
                                 Options = FileOptions.None,
                                 Share = FileShare.ReadWrite

--- a/test/Serilog.Sinks.PersistentFile.Tests/SharedFileSinkTests.cs
+++ b/test/Serilog.Sinks.PersistentFile.Tests/SharedFileSinkTests.cs
@@ -99,5 +99,23 @@ namespace Serilog.Sinks.PersistentFile.Tests
                 Assert.True(size > maxBytes * 2);
             }
         }
+
+        [Fact]
+        public void NoExceptionIsThrownWhenLengthOfFormattedLogEventIsGreaterThanDefaultFileStreamBufferLength()
+        {
+            const int maxBytes = 5000;
+
+            using (var tmp = TempFolder.ForCaller())
+            {
+                var path = tmp.AllocateFilename("txt");
+                var evt = Some.LogEvent(new string('n', maxBytes));
+
+                using (var sink = new SharedFileSink(path, new JsonFormatter(), null))
+                {
+                    var exception = Record.Exception(() => sink.Emit(evt));
+                    Assert.Null(exception);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
to avoid exception being thrown when writebuffer length > DefaultFileStreamBufferLength

closes #24 