### PR TITLE
Multi-Target Frameworks - netstandard20, net472, net80 - for greater compatibility

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -33,7 +33,40 @@ foreach ($src in ls src/*) {
 
     Pop-Location
 }
+# download nuget.exe and put in in the bld/nuget folder
+$bldDir = Join-Path $PSScriptRoot "bld"
+if (-Not (Test-Path $bldDir)) {
+    New-Item -ItemType Directory -Path $bldDir | Out-Null
+}
 
+$nuget = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
+$nugetDir = Join-Path $bldDir "nuget"
+if (-Not (Test-Path $nugetDir)) {
+    echo "build: Creating nuget directory $nugetDir"
+    New-Item -ItemType Directory -Path $nugetDir | Out-Null
+}
+
+$nugetPath = Join-Path $nugetDir "nuget.exe"
+if(!(Test-Path $nugetPath)) {
+    echo "build: Downloading nuget.exe to $nugetPath"
+    Invoke-WebRequest -Uri $nuget -OutFile $nugetPath
+}
+
+
+echo "build: Installing xunit.runner.console NuGet package"
+
+& $nugetPath install xunit.runner.console -Version 2.9.3 -OutputDirectory $bldDir
+if ($LASTEXITCODE -ne 0) { exit 2 }
+$xcrPath = Join-Path $bldDir "xunit.runner.console.2.9.3/tools/net6.0/xunit.console.exe"
+if (-Not (Test-Path $xcrPath)) {
+    echo "build: xunit.runner.console not found at $xcrPath"
+    exit 2
+}
+$xcrNet60Path = "$bldDir/xunit.runner.console.2.9.3/tools/net6.0"
+echo "build: xunit.runner.console found at $bldDir"
+echo "build: xunit.runner.console net6.0 found at $xcrNet60Path"
+
+if ($LASTEXITCODE -ne 0) { exit 2 }
 foreach ($test in ls test/*.Tests) {
     Push-Location $test
 
@@ -41,9 +74,9 @@ foreach ($test in ls test/*.Tests) {
 
     & dotnet test -c Release -f  net8.0
     & dotnet test -c Release -f  net472
-    # & z:\temp\nuget\xunit.runner.console.2.9.3\tools\net6.0\xunit.console.exe z:\downloads\github\forks\serilog-sinks-file\test\Serilog.Sinks.PersistentFile.Tests\bin\Release\netstandard2.0\Serilog.Sinks.PersistentFile.Tests.dll
+    & dotnet build -c Release -f  netstandard2.0 
+    & $xcrPath ./bin/Release/netstandard2.0/Serilog.Sinks.PersistentFile.Tests.dll
     if($LASTEXITCODE -ne 0) { exit 3 }
-
     Pop-Location
 }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -39,7 +39,8 @@ foreach ($test in ls test/*.Tests) {
 
 	echo "build: Testing project in $test"
 
-    & dotnet test -c Release
+    & dotnet test --no-build -c Release -f  net8.0
+    & dotnet test --no-build -c Release -f  net472
     if($LASTEXITCODE -ne 0) { exit 3 }
 
     Pop-Location

--- a/Build.ps1
+++ b/Build.ps1
@@ -39,8 +39,8 @@ foreach ($test in ls test/*.Tests) {
 
 	echo "build: Testing project in $test"
 
-    & dotnet test --no-build -c Release -f  net8.0
-    & dotnet test --no-build -c Release -f  net472
+    & dotnet test -c Release -f  net8.0
+    & dotnet test -c Release -f  net472
     # & z:\temp\nuget\xunit.runner.console.2.9.3\tools\net6.0\xunit.console.exe z:\downloads\github\forks\serilog-sinks-file\test\Serilog.Sinks.PersistentFile.Tests\bin\Release\netstandard2.0\Serilog.Sinks.PersistentFile.Tests.dll
     if($LASTEXITCODE -ne 0) { exit 3 }
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -39,6 +39,9 @@ if (-Not (Test-Path $bldDir)) {
     New-Item -ItemType Directory -Path $bldDir | Out-Null
 }
 
+# download xunit.runner.console from nuget.org and put in bld/nuget folder ONLY if running on Windows
+if ($PSVersionTable.Platform -eq "Win32NT") {
+
 $nuget = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 $nugetDir = Join-Path $bldDir "nuget"
 if (-Not (Test-Path $nugetDir)) {
@@ -50,21 +53,21 @@ $nugetPath = Join-Path $nugetDir "nuget.exe"
 if(!(Test-Path $nugetPath)) {
     echo "build: Downloading nuget.exe to $nugetPath"
     Invoke-WebRequest -Uri $nuget -OutFile $nugetPath
+    }
+
+    echo "build: Installing xunit.runner.console NuGet package"
+
+    & $nugetPath install xunit.runner.console -Version 2.9.3 -OutputDirectory $bldDir
+    if ($LASTEXITCODE -ne 0) { exit 2 }
+    $xcrPath = Join-Path $bldDir "xunit.runner.console.2.9.3/tools/net6.0/xunit.console.exe"
+    if (-Not (Test-Path $xcrPath)) {
+        echo "build: xunit.runner.console not found at $xcrPath"
+        exit 2
+    }
+    $xcrNet60Path = "$bldDir/xunit.runner.console.2.9.3/tools/net6.0"
+    echo "build: xunit.runner.console found at $bldDir"
+    echo "build: xunit.runner.console net6.0 found at $xcrNet60Path"
 }
-
-
-echo "build: Installing xunit.runner.console NuGet package"
-
-& $nugetPath install xunit.runner.console -Version 2.9.3 -OutputDirectory $bldDir
-if ($LASTEXITCODE -ne 0) { exit 2 }
-$xcrPath = Join-Path $bldDir "xunit.runner.console.2.9.3/tools/net6.0/xunit.console.exe"
-if (-Not (Test-Path $xcrPath)) {
-    echo "build: xunit.runner.console not found at $xcrPath"
-    exit 2
-}
-$xcrNet60Path = "$bldDir/xunit.runner.console.2.9.3/tools/net6.0"
-echo "build: xunit.runner.console found at $bldDir"
-echo "build: xunit.runner.console net6.0 found at $xcrNet60Path"
 
 if ($LASTEXITCODE -ne 0) { exit 2 }
 foreach ($test in ls test/*.Tests) {
@@ -75,7 +78,10 @@ foreach ($test in ls test/*.Tests) {
     & dotnet test -c Release -f  net8.0
     & dotnet test -c Release -f  net472
     & dotnet build -c Release -f  netstandard2.0 
-    & $xcrPath ./bin/Release/netstandard2.0/Serilog.Sinks.PersistentFile.Tests.dll
+    #only run xunit.runner.console on Windows
+    if ($PSVersionTable.Platform -eq "Win32NT") {
+        & $xcrPath ./bin/Release/netstandard2.0/Serilog.Sinks.PersistentFile.Tests.dll
+    }
     if($LASTEXITCODE -ne 0) { exit 3 }
     Pop-Location
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -41,6 +41,7 @@ foreach ($test in ls test/*.Tests) {
 
     & dotnet test --no-build -c Release -f  net8.0
     & dotnet test --no-build -c Release -f  net472
+    # & z:\temp\nuget\xunit.runner.console.2.9.3\tools\net6.0\xunit.console.exe z:\downloads\github\forks\serilog-sinks-file\test\Serilog.Sinks.PersistentFile.Tests\bin\Release\netstandard2.0\Serilog.Sinks.PersistentFile.Tests.dll
     if($LASTEXITCODE -ne 0) { exit 3 }
 
     Pop-Location

--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>Sample</AssemblyName>

--- a/example/Sample/Sample.csproj
+++ b/example/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>Sample</AssemblyName>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -4,7 +4,6 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>4.1.0</Version>
   </PropertyGroup>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>4.1.0</Version>
   </PropertyGroup>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -6,7 +6,7 @@
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -15,6 +15,7 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ATOMIC_APPEND;HRESULTS</DefineConstants>
+    <FileVersion>$(Version)</FileVersion>
     <AssemblyVersion>2.3.0.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Version>4.1.0</Version>
   </PropertyGroup>
 
@@ -12,6 +13,9 @@
     <PackageReference Include="serilog" Version="3.1.1" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  </ItemGroup>
+  
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ATOMIC_APPEND;HRESULTS</DefineConstants>
     <AssemblyVersion>2.3.0.0</AssemblyVersion>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -23,12 +23,4 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Serilog.Sinks.PersistentFile.Tests" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Console" Version="4.3.1" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
-    <PackageReference Include="System.Threading.Timer" Version="4.0.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -4,15 +4,13 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>4.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="serilog" Version="3.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="serilog" Version="3.1.1" />
   </ItemGroup>
 
+
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ATOMIC_APPEND;HRESULTS</DefineConstants>
     <FileVersion>$(Version)</FileVersion>
@@ -21,6 +22,13 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Serilog.Sinks.PersistentFile.Tests" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Console" Version="4.3.1" />
+    <PackageReference Include="System.IO.FileSystem" Version="4.0.1" />
+    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.0.11" />
+    <PackageReference Include="System.Threading.Timer" Version="4.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
+++ b/src/Serilog.Sinks.PersistentFile/Serilog.Sinks.PersistentFile.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>4.1.0</Version>
@@ -15,7 +15,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
   </ItemGroup>
-  
+
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);ATOMIC_APPEND;HRESULTS</DefineConstants>
     <AssemblyVersion>2.3.0.0</AssemblyVersion>

--- a/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
@@ -65,17 +65,16 @@ namespace Serilog.Sinks.PersistentFile
             {
                 Directory.CreateDirectory(directory);
             }
-
+            
             // FileSystemRights.AppendData sets the Win32 FILE_APPEND_DATA flag. On Linux this is O_APPEND, but that API is not yet
             // exposed by .NET Core.
             _fileOutput = new FileStream(
                 path,
                 FileMode.Append,
-                FileAccess.ReadWrite,
+                FileAccess.Write,
                 FileShare.ReadWrite,
                 _fileStreamBufferLength,
-                FileOptions.None
-                );
+                FileOptions.None);
 
             _writeBuffer = new MemoryStream();
             _output = new StreamWriter(_writeBuffer,
@@ -98,10 +97,10 @@ namespace Serilog.Sinks.PersistentFile
                     {
                         var oldOutput = _fileOutput;
 
-                        _fileOutput = new FileStream(
+                         _fileOutput = new FileStream(
                             _path,
                             FileMode.Append,
-                            FileAccess.ReadWrite,
+                            FileAccess.Write,
                             FileShare.ReadWrite,
                             length,
                             FileOptions.None);

--- a/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
+++ b/src/Serilog.Sinks.PersistentFile/Sinks/PersistentFile/SharedFileSink.AtomicAppend.cs
@@ -70,13 +70,12 @@ namespace Serilog.Sinks.PersistentFile
             // exposed by .NET Core.
             _fileOutput = new FileStream(
                 path,
-                new FileStreamOptions{
-                    Access = FileAccess.Write,
-                    BufferSize = _fileStreamBufferLength,
-                    Mode = FileMode.Append,
-                    Options = FileOptions.None,
-                    Share = FileShare.ReadWrite
-                });
+                FileMode.Append,
+                FileAccess.ReadWrite,
+                FileShare.ReadWrite,
+                _fileStreamBufferLength,
+                FileOptions.None
+                );
 
             _writeBuffer = new MemoryStream();
             _output = new StreamWriter(_writeBuffer,
@@ -101,12 +100,11 @@ namespace Serilog.Sinks.PersistentFile
 
                         _fileOutput = new FileStream(
                             _path,
-                            new FileStreamOptions{
-                                Access = FileAccess.Write,
-                                Mode = FileMode.Append,
-                                Options = FileOptions.None,
-                                Share = FileShare.ReadWrite
-                            });
+                            FileMode.Append,
+                            FileAccess.ReadWrite,
+                            FileShare.ReadWrite,
+                            length,
+                            FileOptions.None);
                         _fileStreamBufferLength = length;
 
                         oldOutput.Dispose();

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -22,8 +22,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>true</IsTestProject>

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>default</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -7,13 +7,13 @@
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -23,6 +23,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
+++ b/test/Serilog.Sinks.PersistentFile.Tests/Serilog.Sinks.PersistentFile.Tests.csproj
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Hello,

I am in the same predicament as mentioned in issue #28.  I also have a net472 project that cannot reference the latest version of this package, because it only targets net80.   As in pull request #29, submitted by [julealgon](https://github.com/julealgon), I also target netstandard20.  However, I went a step further and mulit-target net80 and net472.  An argument can be made that netstandard20 and net80 would be enough. But I did net472, for an actual full framework version, since full framework dotnet is still supported.  

Please consider this pull request for inclusion into the main project.   

I have also modified and run the tests over all three builds.   They all succeed when run locally (win11 x64 machine).  There was one issue, that the netstandard20 version of the tests are not supported in the xunit.runner.visualstudio adapter.  So, I modified Build.ps1 to download xunit.runner.console and run the tests using that.  As mentioned, all tests succeed!  If you don't find this addition, of the tests, acceptable, please let me know and I can remove them.    But I wanted to include them for, if nothing else, as proof that all your tests have passed.

Cheers!


```
xUnit.net Console Runner v2.9.3+9712244020 (64-bit .NET 6.0.36)
  Discovering: Serilog.Sinks.PersistentFile.Tests
  Discovered:  Serilog.Sinks.PersistentFile.Tests
  Starting:    Serilog.Sinks.PersistentFile.Tests
  Finished:    Serilog.Sinks.PersistentFile.Tests
=== TEST EXECUTION SUMMARY ===
   Serilog.Sinks.PersistentFile.Tests  Total: 66, Errors: 0, Failed: 0, Skipped: 0, Time: 2.507s
```
